### PR TITLE
Improve build failure comment wording in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           if [ "${{ steps.build.outcome }}" == "success" ]; then
             comment="Build passed! Merging is allowed."
           else
-            comment="Build failed! Please check the errors."
+            comment="Build failed! Please fix the errors."
           fi
 
           # Post the comment using GitHub CLI


### PR DESCRIPTION
This PR updates the build failure comment message in the CI workflow to use more actionable language. The phrase "Please check the errors" has been replaced with "Please fix the errors" to provide clearer guidance to contributors when a build fails, encouraging them to resolve the issues rather than simply review them.