### PR TITLE
Update build success comment message in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ always() }}  # Run this step even if the previous step fails
         run: |
           if [ "${{ steps.build.outcome }}" == "success" ]; then
-            comment="Build passed! Merging is allowed."
+            comment="Build passed! Merging is now allowed."
           else
             comment="Build failed! Please fix the errors."
           fi


### PR DESCRIPTION
This PR updates the comment message displayed when a build passes in the GitHub Actions CI workflow. The message has been slightly rephrased from "Build passed! Merging is allowed." to "Build passed! Merging is now allowed." to improve clarity and provide a more immediate, contextual indication that merging is permitted following a successful build.